### PR TITLE
Revert "Update circe-yaml to 0.15.1"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val core = project
       "dev.optics"     %% "monocle-core"        % monocleVersion,
       "org.scodec"     %% "scodec-bits"         % scodecVersion,
       "org.scala-lang" %% "scala3-staging"      % Scala3,
-      "io.circe"       %% "circe-yaml"          % "0.15.1",
+      "io.circe"       %% "circe-yaml"          % "0.14.2",
       "org.scalameta"  %% "munit"               % munitVersion   % Test,
       "org.scalameta"  %% "munit-scalacheck"    % munitVersion   % Test,
       "org.typelevel"  %% "munit-cats-effect-3" % munitCEVersion % Test


### PR DESCRIPTION
Reverts didx-xyz/castanet#6

Fixed interdependency conflict when using castanet in gleibnif